### PR TITLE
Fixed parser bug when last read-buffer character is an opening quote.

### DIFF
--- a/parseCSV.m
+++ b/parseCSV.m
@@ -272,7 +272,8 @@ NSString * parseString(char *text_p, char *previousStop_p, NSStringEncoding enco
 		}
 		
 		text_p = buffer_p;
-		
+		quoteCount = 0;
+        
 		while (*text_p != '\0') {
 			// If we don't have a delimiter yet and this is the first line...
 			if (firstLine && _delimiter == '\0') {


### PR DESCRIPTION
The parser breaks when the last character of the *text_p buffer is an opening quotation mark.

I have a CSV with rows like this:

```
 73,General,Foo,bar,morebar,"1,3,5,4,2",Foo1,© Blah blah,Foo2,© Blah blah,Foo3,© Blah blah,Foo4,© Blah blah,Foo5,© Blah blah,73,NO,
```

(Notice the empty cell after the last element, but that might be irrelevant for this Issue.)

I have discovered that the parser stops working if the last row in the buffer ends up looking like this:

```
 73,General,Foo,bar,morebar,"
```

In this case the last output row is 73. The parser gets confused by an incorrect quote count, and doesn't output rows 74+.

I am not 100% sure that my fix doesn't have any side effects and I don't have time to thoroughly check everything. It seems to work fine for me.

Cheers!
